### PR TITLE
refactor: support py38

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,31 @@ This will change your app to link out to buymeacoffee instead of Stripe, and wil
 ### Feedback:
 
 If you have feedback about this package, please reach out to me on [twitter](https://twitter.com/tylerjrichards) or file an issue in [this repo](https://github.com/tylerjrichards/st-paywall/issues) and I will do my best to help you out.
+
+### Local Development:
+
+Local development setup with python >= 3.8 installed:
+
+- Fork the repository to your own github account from the top of [this page](https://github.com/tylerjrichards/st-paywall)
+- Clone your forked repository to your local system
+- Initialize a virtual environment with python 3.8 installed
+- Install the package locally with pip in editable mode
+- Install streamlit
+- Run the sample application
+- Edit `src/st_paywall` as needed and re-run the sample application
+
+Sample:
+
+```sh
+# clone fork
+git clone git@github.com:$YOUR_USERNAME/st-paywall.git
+# init virtual env
+cd st-paywall
+python -m venv venv
+. ./venv/bin/activate
+# Install dependencies
+python -m pip install -e .
+python -m pip install streamlit
+# Run sample application!
+python -m streamlit run streamlit_app.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,4 @@ dependencies = [
     "httpx-oauth",
     "pyjwt"
 ]
-requires-python = ">=3.10.0"
-
-
-
-
+requires-python = ">=3.8.0"

--- a/src/st_paywall/google_auth.py
+++ b/src/st_paywall/google_auth.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 
 import jwt
 import streamlit as st
@@ -34,7 +35,7 @@ async def get_authorization_url(client: GoogleOAuth2, redirect_url: str):
 
 
 def markdown_button(
-    url: str, text: str | None = None, color="#FD504D", sidebar: bool = True
+    url: str, text: Optional[str] = None, color="#FD504D", sidebar: bool = True
 ):
     markdown = st.sidebar.markdown if sidebar else st.markdown
 
@@ -90,7 +91,7 @@ def show_login_button():
     markdown_button(authorization_url, "Login with Google")
 
 
-def get_logged_in_user_email() -> str | None:
+def get_logged_in_user_email() -> Optional[str]:
     if "email" in st.session_state:
         return st.session_state.email
 


### PR DESCRIPTION
- swap py310 syntax for `typing.Optional`
- adds local development readme section

feel free to change to py39 minimum
also doc section could go in read the docs

closes #17 