### PR TITLE
subscription fix for cancelled subs

### DIFF
--- a/src/st_paywall/stripe_auth.py
+++ b/src/st_paywall/stripe_auth.py
@@ -19,12 +19,12 @@ def redirect_button(
     payment_provider: str = "stripe",
 ):
     testing_mode = st.secrets.get("testing_mode", False)
-    stripe.api_key = get_api_key()
-    stripe_link = (
-        st.secrets["stripe_link_test"] if testing_mode else st.secrets["stripe_link"]
-    )
     encoded_email = urllib.parse.quote(customer_email)
     if payment_provider == "stripe":
+        stripe.api_key = get_api_key()
+        stripe_link = (
+            st.secrets["stripe_link_test"] if testing_mode else st.secrets["stripe_link"]
+        )
         button_url = f"{stripe_link}?prefilled_email={encoded_email}"
     elif payment_provider == "bmac":
         button_url = f"{st.secrets['bmac_link']}"
@@ -51,8 +51,10 @@ def redirect_button(
 
 def get_customer_emails():
     stripe.api_key = get_api_key()
-    customers = stripe.Customer.list()
+    subscriptions = stripe.Subscription.list(status='active')
     emails = []
-    for i in customers["data"]:
-        emails.append(i["email"])
+    for subscription in subscriptions["data"]:
+        customer_id = subscription["customer"]
+        customer = stripe.Customer.retrieve(customer_id)
+        emails.append(customer["email"])
     return emails


### PR DESCRIPTION
It was kindly noted to be that this just grabs the customers, not the current subscribers to your Stripe account. So theoretically, someone could subscribe, and unsubscribe, and if they were still in the customers list, they would be able to keep access to the account. https://github.com/tylerjrichards/st-paywall/issues/27

This fix pulls the active subscriptions, then uses the customer api to find the associated email. Much better! It also fixes https://github.com/tylerjrichards/st-paywall/issues/25