### PR TITLE
Adding subscriptions return from Stripe to st.session_state

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ I made st-paywall so data scientists and LLM developers can create small busines
 
 ## Overview
 
-This package gives you one basic function (`add_auth`) that adds subscription functionality to your Streamlit apps. `add_auth` will add both a Google login button if they are not logged in, and a Stripe (or Buy Me A Coffee) subscription button to your sidebar if they are not subscribed. If they are subscribed, `st.session_state.user_subscribed` will be true, and if they are logged in, `st.session_state.email` will have their email.
+This package gives you one basic function (`add_auth`) that adds subscription functionality to your Streamlit apps. `add_auth` will add both a Google login button if they are not logged in, and a Stripe (or Buy Me A Coffee) subscription button to your sidebar if they are not subscribed. If they are subscribed, `st.session_state.user_subscribed` will be true, and if they are logged in, `st.session_state.email` will have their email. `st.session_state.subscriptions` will have the info about their subscription(s).
 If the `required` parameter is `True`, the app will stop with `st.stop()` if the user is not logged in and subscribed. Otherwise, you the developer will have control over exactly how you want to paywall the apps!
 
 I hope you use this to create tons of value, and capture some of it with the magic of Streamlit.

--- a/docs/subscription-stripe.md
+++ b/docs/subscription-stripe.md
@@ -1,6 +1,6 @@
 # Subscription with Stripe
 
-In order to set up your Stripe (the best and easiest payment infrastructure in the world), go to [Stripe.com](https://stripe.com) and make an account. Once you make an account, you need to make a [payment subscription link](https://dashboard.stripe.com/test/payment-links/create) (which is in test mode by default) and add the link to your app (currently held in streamlit_app.py). If the user to your app logs in and has not already signed up and paid via Stripe, they will be asked to subscribe before they can see the rest of the app.
+In order to set up your Stripe (the best and easiest payment infrastructure in the world), go to [Stripe.com](https://stripe.com) and make an account. Once you make an account, you need to make a [payment subscription link](https://dashboard.stripe.com/test/payment-links/create) (which is in test mode by default) and add the link to your app (currently held in streamlit_app.py). If the user to your app logs in and has not already signed up and paid via Stripe, they will be asked to subscribe before they can see the rest of the app. The package will also add information about the user's subscriptions that it gets from the Stripe API back to you via session state, in a param called 'subscriptions'. If you want to have multiple subscriptions, or filter only for a specific subscription, you can use this information to do so!
 
 The subscription link should be added to secrets.toml like this.
 

--- a/src/st_paywall/aggregate_auth.py
+++ b/src/st_paywall/aggregate_auth.py
@@ -11,6 +11,7 @@ def add_auth(
     login_button_text: str = "Login with Google",
     login_button_color: str = "#FD504D",
     login_sidebar: bool = True,
+
 ):
     if required:
         require_auth(

--- a/src/st_paywall/stripe_auth.py
+++ b/src/st_paywall/stripe_auth.py
@@ -60,5 +60,6 @@ def is_active_subscriber(email: str) -> bool:
         return False
 
     subscriptions = stripe.Subscription.list(customer=customer["id"])
+    st.session_state.subscriptions = subscriptions
 
     return len(subscriptions) > 0


### PR DESCRIPTION
Adding the raw subscription return from Stripe the session_state so it can be accessible to other parts of any streamlit project.
As discussed here: https://github.com/tylerjrichards/st-paywall/issues/38