### PR TITLE
st.experimental_rerun was deprecated in version 1.27.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ dependencies = [
     "stripe",
     "httpx-oauth",
     "pyjwt",
+    "streamlit>=1.27.0",
 ]
 requires-python = ">=3.8.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx-oauth
 pyjwt
 st-paywall
 mkdocs
+streamlit>=1.27.0

--- a/src/st_paywall/aggregate_auth.py
+++ b/src/st_paywall/aggregate_auth.py
@@ -40,7 +40,7 @@ def require_auth():
     if st.sidebar.button("Logout", type="primary"):
         del st.session_state.email
         del st.session_state.user_subscribed
-        st.experimental_rerun()
+        st.rerun()
 
 
 def optional_auth():
@@ -71,4 +71,4 @@ def optional_auth():
         if st.sidebar.button("Logout", type="primary"):
             del st.session_state.email
             del st.session_state.user_subscribed
-            st.experimental_rerun()
+            st.rerun()


### PR DESCRIPTION
We should use st.rerun instead. As decribed on the docs: https://docs.streamlit.io/library/api-reference/control-flow/st.experimental_rerun

and discussed at https://github.com/tylerjrichards/st-paywall/issues/39