### PR TITLE
fix the keyerror for communicating with buy me a coffee when no supporters yet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "st-paywall"
-version = "0.1.8"
+version = "0.1.9"
 description = "A Python package for creating subscription Streamlit apps"
 authors = [
     {name = "Tyler Richards", email = "tylerjrichards@gmail.com"}

--- a/src/st_paywall/buymeacoffee_auth.py
+++ b/src/st_paywall/buymeacoffee_auth.py
@@ -6,7 +6,7 @@ import streamlit as st
 def extract_payer_emails(json_response):
     payer_emails = []
 
-    for item in json_response["data"]:
+    for item in json_response.get("data", []):
         payer_email = item["payer_email"]
         payer_emails.append(payer_email)
 


### PR DESCRIPTION
When starting out with the buymeacoffee and having no supporters yet we get a KeyError, since the buymeacoffee API responds with 200 and `{'error': 'No subscriptions'}`.