### PR TITLE
use env variables if you don't have access to secrets

### DIFF
--- a/src/st_paywall/aggregate_auth.py
+++ b/src/st_paywall/aggregate_auth.py
@@ -2,7 +2,7 @@ import streamlit as st
 from .stripe_auth import is_active_subscriber as is_stripe_subscriber, redirect_button
 from .buymeacoffee_auth import get_bmac_payers
 
-payment_provider = st.secrets.get("payment_provider") or os.getenv("PAYMENT_PROVIDER", "stripe")
+payment_provider = st.secrets["api_keys"]["payment_provider"]
 
 
 def add_auth(required: bool = True, 

--- a/src/st_paywall/aggregate_auth.py
+++ b/src/st_paywall/aggregate_auth.py
@@ -2,7 +2,7 @@ import streamlit as st
 from .stripe_auth import is_active_subscriber as is_stripe_subscriber, redirect_button
 from .buymeacoffee_auth import get_bmac_payers
 
-payment_provider = st.secrets.get("payment_provider", "stripe")
+payment_provider = st.secrets.get("payment_provider") or os.getenv("PAYMENT_PROVIDER", "stripe")
 
 
 def add_auth(required: bool = True, 

--- a/src/st_paywall/stripe_auth.py
+++ b/src/st_paywall/stripe_auth.py
@@ -4,11 +4,11 @@ import urllib.parse
 
 
 def get_api_key() -> str:
-    testing_mode = st.secrets.get("testing_mode") or os.getenv("TESTING_MODE", False)
+    testing_mode = st.secrets["api_keys"]["testing_mode"]
     return (
-        st.secrets["stripe_api_key_test"] or os.getenv("STRIPE_API_KEY_TEST")
+        st.secrets["api_keys"]["stripe_api_key_test"]
         if testing_mode
-        else st.secrets["stripe_api_key"] or os.getenv("STRIPE_API_KEY")
+        else st.secrets["api_keys"]["stripe_api_key"]
     )
 
 
@@ -19,14 +19,14 @@ def redirect_button(
     payment_provider: str = "stripe",
     use_sidebar: bool = True,
 ):
-    testing_mode = st.secrets.get("testing_mode") or os.getenv("TESTING_MODE", False)
+    testing_mode = st.secrets["api_keys"]["testing_mode"]
     encoded_email = urllib.parse.quote(customer_email)
     if payment_provider == "stripe":
         stripe.api_key = get_api_key()
         stripe_link = (
-            st.secrets["stripe_link_test"] or os.getenv("STRIPE_LINK_TEST")
+            st.secrets["api_keys"]["stripe_link_test"]
             if testing_mode
-            else st.secrets["stripe_link"] or os.getenv("STRIPE_LINK")
+            else st.secrets["api_keys"]["stripe_link"]
         )
         button_url = f"{stripe_link}?prefilled_email={encoded_email}"
     elif payment_provider == "bmac":

--- a/src/st_paywall/stripe_auth.py
+++ b/src/st_paywall/stripe_auth.py
@@ -4,11 +4,11 @@ import urllib.parse
 
 
 def get_api_key() -> str:
-    testing_mode = st.secrets.get("testing_mode", False)
+    testing_mode = st.secrets.get("testing_mode") or os.getenv("TESTING_MODE", False)
     return (
-        st.secrets["stripe_api_key_test"]
+        st.secrets["stripe_api_key_test"] or os.getenv("STRIPE_API_KEY_TEST")
         if testing_mode
-        else st.secrets["stripe_api_key"]
+        else st.secrets["stripe_api_key"] or os.getenv("STRIPE_API_KEY")
     )
 
 
@@ -19,14 +19,14 @@ def redirect_button(
     payment_provider: str = "stripe",
     use_sidebar: bool = True,
 ):
-    testing_mode = st.secrets.get("testing_mode", False)
+    testing_mode = st.secrets.get("testing_mode") or os.getenv("TESTING_MODE", False)
     encoded_email = urllib.parse.quote(customer_email)
     if payment_provider == "stripe":
         stripe.api_key = get_api_key()
         stripe_link = (
-            st.secrets["stripe_link_test"]
+            st.secrets["stripe_link_test"] or os.getenv("STRIPE_LINK_TEST")
             if testing_mode
-            else st.secrets["stripe_link"]
+            else st.secrets["stripe_link"] or os.getenv("STRIPE_LINK")
         )
         button_url = f"{stripe_link}?prefilled_email={encoded_email}"
     elif payment_provider == "bmac":


### PR DESCRIPTION
I have a Streamlit application deployed to Railway, and on that platform I can't access st.secrets data, only ENV variables.

This PR should cover both cases.
I'm not a Python developer, so feel free to change it to make it more efficient or to avoid bugs