### PR TITLE
build: moved requirements.txt fully into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-[build-system]
-requires = ["setuptools", "wheel"]
 
 [project]
 name = "st-paywall"
@@ -13,5 +11,16 @@ license = {text = "MIT"}
 dependencies = [
     "stripe",
     "streamlit>=1.42.0",
+    "httpx-oauth>=0.16.1",
+    "pyjwt>=2.10.1",
+    "authlib>=1.6.0",
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[dependency-groups]
+dev = [
+    "mkdocs>=1.6.1",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-stripe
-httpx-oauth
-pyjwt
-st-paywall==1.0.0
-mkdocs
-streamlit>=1.42.0
-authlib>=1.3.2


### PR DESCRIPTION
no need for the requirements.txt if you use pyproject.toml. I bumped python version as newer streamlit versions are not compatible with <3.9