### PR TITLE
replace st.experimental_user with st.user

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ from st_paywall import add_auth
 st.title("My Subscription App")
 
 # Handle Streamlit's native authentication
-if not st.experimental_user.is_logged_in:
+if not st.user.is_logged_in:
     if st.button("Log in using Streamlit's native authentication"):
         st.login()
 else:
@@ -40,7 +40,7 @@ else:
     
     # Your app code here - only runs for subscribed users
     st.write("Welcome, subscriber!")
-    st.write(f"Your email is: {st.experimental_user.email}")
+    st.write(f"Your email is: {st.user.email}")
 ```
 
 ## Configuration
@@ -86,7 +86,7 @@ from st_paywall import add_auth
 
 st.title("My Subscription App")
 
-if not st.experimental_user.is_logged_in:
+if not st.user.is_logged_in:
     st.write("Please log in to access this app")
     if st.button("Log in"):
         st.login()

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,4 +2,4 @@
 
 This package uses Streamlit's native authentication system. You'll need to configure authentication in your Streamlit app's settings in secrets.
 
-For more information about setting up Streamlit's authentication, please refer to [Streamlit's documentation](https://docs.streamlit.io/develop/api-reference/utilities/st.experimental_user).
+For more information about setting up Streamlit's authentication, please refer to [Streamlit's documentation](https://docs.streamlit.io/develop/api-reference/utilities/st.user).

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ I made st-paywall so data scientists and LLM developers can create small busines
 
 ## Overview
 
-This package gives you one basic function (`add_auth`) that adds subscription functionality to your Streamlit apps. `add_auth` works with Streamlit's native authentication system and adds a Stripe (or Buy Me A Coffee) subscription button if users are not subscribed. If they are subscribed, `st.session_state.user_subscribed` will be true, and you can access their email through `st.experimental_user.email`. `st.session_state.subscriptions` will have the info about their subscription(s), which you can use for more fine-grained control of your app logic. 
+This package gives you one basic function (`add_auth`) that adds subscription functionality to your Streamlit apps. `add_auth` works with Streamlit's native authentication system and adds a Stripe (or Buy Me A Coffee) subscription button if users are not subscribed. If they are subscribed, `st.session_state.user_subscribed` will be true, and you can access their email through `st.user.email`. `st.session_state.subscriptions` will have the info about their subscription(s), which you can use for more fine-grained control of your app logic. 
 
 If the `required` parameter is `True`, the app will stop with `st.stop()` if the user is not logged in and subscribed. Otherwise, you the developer will have control over exactly how you want to paywall the apps! 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "st-paywall"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Python package for creating subscription Streamlit apps"
 authors = [
     {name = "Tyler Richards", email = "tylerjrichards@gmail.com"}
@@ -12,6 +12,6 @@ readme = "README.md"
 license = {text = "MIT"}
 dependencies = [
     "stripe",
-    "streamlit>=1.42.0",
+    "streamlit>=1.45.0",
 ]
 requires-python = ">=3.8.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 stripe
 httpx-oauth
 pyjwt
-st-paywall==1.0.0
+st-paywall==1.0.2
 mkdocs
-streamlit>=1.42.0
+streamlit>=1.45.0
 authlib>=1.3.2

--- a/src/st_paywall/aggregate_auth.py
+++ b/src/st_paywall/aggregate_auth.py
@@ -34,10 +34,10 @@ def is_subscriber(email: str) -> bool:
 
 def require_auth(show_redirect_button: bool = True, subscription_button_text: str = 'Subscribe now!', button_color: str = "#FD504D", use_sidebar: bool = True):
     """Require authentication and payment verification to proceed."""
-    if not st.experimental_user.is_logged_in:
+    if not st.user.is_logged_in:
         st.stop()
 
-    user_email = st.experimental_user.email
+    user_email = st.user.email
     is_subscribed = is_subscriber(user_email)
 
     if not is_subscribed:
@@ -58,8 +58,8 @@ def require_auth(show_redirect_button: bool = True, subscription_button_text: st
 def optional_auth(show_redirect_button: bool=True, subscription_button_text: str = 'Subscribe now!', button_color: str = "#FD504D", use_sidebar: bool = True):
     """Add optional authentication and payment verification."""
     user_email = None
-    if st.experimental_user.is_logged_in:
-        user_email = st.experimental_user.email
+    if st.user.is_logged_in:
+        user_email = st.user.email
     
     is_subscribed = user_email and is_subscriber(user_email)
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,16 +5,16 @@ st.set_page_config(layout="wide")
 st.title("🎈 Tyler's Subscription app POC 🎈")
 st.balloons()
 
-if not st.experimental_user.is_logged_in:
+if not st.user.is_logged_in:
     if st.button("Log in using Streamlit's native authentication"):
         st.login()
 
 else:
     if st.button("Log out"):
         st.logout()
-    st.write(f"Hello, {st.experimental_user.name}!")
+    st.write(f"Hello, {st.user.name}!")
     st.write('Now we can use this to check if the user is a subscriber!')
     add_auth(required=True, show_redirect_button=True, use_sidebar=False)
 
     st.write("Congrats, you are subscribed!")
-    st.write("the email of the user is " + str(st.experimental_user.email))
+    st.write("the email of the user is " + str(st.user.email))


### PR DESCRIPTION
Using this library results in this message:

```txt
2025-06-12 19:16:05.414 Please replace `st.experimental_user` with `st.user`.

`st.experimental_user` will be removed after 2025-11-06.
```

replacing this stops the error as st.experimental_user is no longer used and replaced with st.user.